### PR TITLE
Added ProcInterface::getInFrame{W,H}() virtual methods

### DIFF
--- a/ogles_gpgpu/common/proc/base/multipassproc.h
+++ b/ogles_gpgpu/common/proc/base/multipassproc.h
@@ -120,6 +120,16 @@ public:
      * Get the output frame height.
      */
     virtual int getOutFrameH() const;
+    
+    /**
+     * Get the input frame width.
+     */
+    virtual int getInFrameW() const;
+    
+    /**
+     * Get the input frame height.
+     */
+    virtual int getInFrameH() const;
 
     /**
      * Returns true if output size < input size.

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -128,6 +128,20 @@ public:
     virtual int getOutFrameH() const {
         return outFrameH;
     }
+    
+    /**
+     * Get the input frame width.
+     */
+    virtual int getInFrameW() const {
+        return inFrameW;
+    }
+    
+    /**
+     * Get the input frame height.
+     */
+    virtual int getInFrameH() const {
+        return inFrameH;
+    }
 
     /**
      * Returns true if output size < input size.
@@ -216,11 +230,11 @@ protected:
 
     GLenum inputDataFmt;    // input pixel data format
 
-    int inFrameW;   // input frame width
-    int inFrameH;   // input frame height
+    int inFrameW = 0;   // input frame width
+    int inFrameH = 0;   // input frame height
 
-    int outFrameW;  // output frame width
-    int outFrameH;  // output frame height
+    int outFrameW = 0;  // output frame width
+    int outFrameH = 0;  // output frame height
 };
 
 }

--- a/ogles_gpgpu/common/proc/base/procinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/procinterface.cpp
@@ -27,9 +27,14 @@ void ProcInterface::prepare(int inW, int inH, GLenum inFmt, int index) {
     if(index == 0) {
         setExternalInputDataFormat(inFmt);
     }
-        
-    init(inW, inH, index, (index == 0) && (inFmt != GL_NONE));
-        
+    
+    if((getInFrameW() == 0) && (getInFrameH() == 0)) {
+        init(inW, inH, index, (index == 0) && (inFmt != GL_NONE));
+    }
+    else {
+        reinit(inW, inH, (index == 0) && (inFmt != GL_NONE));
+    }
+    
     bool useMipmaps = false; // TODO:
     bool willDownScale = false;
     if(subscribers.size() != 0) {

--- a/ogles_gpgpu/common/proc/base/procinterface.h
+++ b/ogles_gpgpu/common/proc/base/procinterface.h
@@ -118,6 +118,16 @@ public:
      * Get the output frame height.
      */
     virtual int getOutFrameH() const = 0;
+    
+    /**
+     * Get the input frame width.
+     */
+    virtual int getInFrameW() const = 0;
+    
+    /**
+     * Get the input frame height.
+     */
+    virtual int getInFrameH() const = 0;
 
     /**
      * Returns true if output size < input size.

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -40,7 +40,7 @@ void VideoSource::operator()(const Size2d &size, void* pixelBuffer, bool useRawP
 {
     assert(pipeline);
     
-    if (firstFrame)
+    if (firstFrame || size != frameSize)
     {
         configurePipeline(size, inputPixFormat);
         firstFrame = false;


### PR DESCRIPTION
- Add implementations for ProcBase and MultiPassProc
- Use c++11 iterators for readability (MultiPassProc)
- Perform reinit() if FBOs have been allocated in ProcInterface::prepare() calls
