### PR TITLE
Pr.diffproc.clamp.fix

### DIFF
--- a/ogles_gpgpu/common/proc/base/procinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/procinterface.cpp
@@ -30,6 +30,7 @@ void ProcInterface::process(GLuint id, GLuint useTexUnit, GLenum target, int ind
     if(logger) logger(std::string(getProcName()) + " end");
         
     for(auto &subscriber : subscribers) {
+        subscriber.first->useTexture(getOutputTexId(), getTextureUnit(), GL_TEXTURE_2D, subscriber.second);
         subscriber.first->process(subscriber.second, logger);
     }
 }

--- a/ogles_gpgpu/common/proc/blend.cpp
+++ b/ogles_gpgpu/common/proc/blend.cpp
@@ -43,9 +43,6 @@ void BlendProc::setUniforms()
 int BlendProc::render(int position)
 {
     // Always render on position == 0
-    if(position == 0)
-    {        
-        FilterProcBase::render(position);
-    }
+    TwoInputProc::render(position);
     return position;
 }

--- a/ogles_gpgpu/common/proc/diff.cpp
+++ b/ogles_gpgpu/common/proc/diff.cpp
@@ -16,8 +16,8 @@ const char *DiffProc::fshaderDiffSrc = OG_TO_STR
  {
      vec4 centerIntensity = texture2D(inputImageTexture, textureCoordinate);
      vec4 centerIntensity2 = texture2D(inputImageTexture2, textureCoordinate);
-     vec4 dt = (centerIntensity-centerIntensity2) * strength;
-     gl_FragColor = clamp(dt, 0.0, 1.0);
+     vec3 dt = (centerIntensity.rgb-centerIntensity2.rgb) * strength;
+     gl_FragColor = vec4(vec3(clamp(dt, 0.0, 1.0)), 1.0);
  });
 
 
@@ -40,13 +40,5 @@ void DiffProc::setUniforms()
 
 int DiffProc::render(int position)
 {
-    //return FilterProcBase::render(position);
-#if 0
-    switch(position)
-    {
-        case 0: hasTex1 = true; break;
-        case 1: hasTex2 = true; break;
-    }
-#endif
     return TwoInputProc::render(position);
 }

--- a/ogles_gpgpu/common/proc/iir.cpp
+++ b/ogles_gpgpu/common/proc/iir.cpp
@@ -52,6 +52,18 @@ IirFilterProc::IirFilterProc(FilterKind kind, float alpha, float strength)
     }
 }
 
+int IirFilterProc::init(int inW, int inH, unsigned int order, bool prepareForExternalInput)
+{
+    isFirst = true;
+    return MultiPassProc::init(inW, inH, order, prepareForExternalInput);
+}
+
+int IirFilterProc::reinit(int inW, int inH, bool prepareForExternalInput)
+{
+    isFirst = true;
+    return MultiPassProc::reinit(inW, inH, prepareForExternalInput);
+}
+
 IirFilterProc::~IirFilterProc() {}
 ProcInterface* IirFilterProc::getInputFilter() const { return &m_impl->iirProc; }
 ProcInterface* IirFilterProc::getOutputFilter() const { return m_impl->lastProc; }
@@ -61,13 +73,11 @@ int IirFilterProc::render(int position)
     m_impl->iirProc.process(0);
     if(m_impl->kind == kHighPass)
     {
+        // At this point useTexture() has been called and diffProc should have:
+        // texture #1 : <- Input
+        // texture #2 : <- IirProc
         m_impl->diffProc.process(0);
     }
-    
-    // Connect FIFO output to second input of IIR for frames >= 1
-    auto &fifoProc = m_impl->fifoProc;
-    auto &iirProc = m_impl->iirProc;
-    iirProc.useTexture2(fifoProc.getOutputTexId(), fifoProc.getTextureUnit(), GL_TEXTURE_2D);
     return 0;
 }
 
@@ -76,7 +86,7 @@ void IirFilterProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int 
     auto &fifoProc = m_impl->fifoProc;
     auto &iirProc = m_impl->iirProc;
 
-    if(m_impl->kind == kHighPass)
+    if((m_impl->kind == kHighPass) && isFirst)
     {
         auto &diffProc = m_impl->diffProc;
         
@@ -84,13 +94,23 @@ void IirFilterProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int 
         diffProc.useTexture(id, useTexUnit, target, 0);
         diffProc.useTexture2(iirProc.getOutputTexId(), iirProc.getTextureUnit(), GL_TEXTURE_2D);
     }
-
-    // IIR filter input (same image for first frame)
-    iirProc.useTexture(id, useTexUnit, target, 0);
-    iirProc.useTexture2(id, useTexUnit, GL_TEXTURE_2D);
     
-    // FIFO input (from IIR)
-    fifoProc.useTexture(iirProc.getOutputTexId(), iirProc.getTextureUnit(), GL_TEXTURE_2D, 0);
+    // IIR filter input (same image for first frame)
+
+    if(isFirst)
+    {
+        isFirst = false;
+        iirProc.useTexture(id, useTexUnit, target, 0);
+        iirProc.useTexture2(id, useTexUnit, GL_TEXTURE_2D);
+        
+        // FIFO input (from IIR)
+        fifoProc.useTexture(iirProc.getOutputTexId(), iirProc.getTextureUnit(), GL_TEXTURE_2D, 0);
+    }
+    else
+    {
+        // Connect FIFO output to second input of IIR for frames >= 1
+        iirProc.useTexture2(fifoProc.getOutputTexId(), fifoProc.getTextureUnit(), GL_TEXTURE_2D);
+    }
 }
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/iir.h
+++ b/ogles_gpgpu/common/proc/iir.h
@@ -26,6 +26,10 @@ public:
     virtual ProcInterface* getInputFilter() const;
     virtual ProcInterface* getOutputFilter() const;
     
+    virtual int init(int inW, int inH, unsigned int order, bool prepareForExternalInput = false);
+    virtual int reinit(int inW, int inH, bool prepareForExternalInput = false);
+    
+    bool isFirst = true;
     std::unique_ptr<Impl> m_impl;
 };
 

--- a/ogles_gpgpu/common/proc/two.h
+++ b/ogles_gpgpu/common/proc/two.h
@@ -47,6 +47,19 @@ public:
     
     void setWaitForSecondTexture(bool flag) { waitForSecondTexture = flag; }
     
+    
+    /**
+     * Has fist texture
+     */
+    
+    virtual bool getHasFirstTexture() const { return hasTex1; }
+    
+    /**
+     * Has second texture
+     */
+    
+    virtual bool getHasSecondTexture() const { return hasTex2; }
+    
 protected:
     
     virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);


### PR DESCRIPTION
Avoid clamp in diff proc alpha channel; add useTexture() per step initialization in top level interface process() calls (first filter in pipeline variant).
