### PR TITLE
add platform specific gpu dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,32 @@ language:
 sudo:
   - false
 
+dist:
+  - trusty
+
 # Install packages differs for container-based infrastructure
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
-# * http://stackoverflow.com/a/30925448/2288008
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - python3
+      # For Qt
+      - libegl1-mesa-dev
 
-      # python3-pip package is not available, use 'easy_install3':
-      # * https://github.com/travis-ci/apt-package-whitelist/issues/768
-      - python3-setuptools # easy_install3
+      # xorg-macros: https://github.com/BlueDragonX/xf86-input-mtrack/issues/27#issuecomment-186871891
+      - xutils-dev
 
-      # https://github.com/travis-ci-tester/travis-test-clang-cxx-11
-      - libstdc++-4.8-dev
-
-      # https://github.com/travis-ci-tester/travis-test-gcc-cxx-11
-      - g++-4.8
+      # Packages for Android development: http://superuser.com/a/360398/252568
+      - libncurses5:i386
+      - libstdc++6:i386
+      - zlib1g:i386
   
 matrix:
   include:
     # Linux {
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=gcc-4-8-pic-hid-sections INSTALL=--strip
+      env: CONFIG=Release TOOLCHAIN=gcc-pic-hid-sections INSTALL=
     # - os: linux
-    #   env: CONFIG=Debug TOOLCHAIN=gcc-4-8-pic-hid-sections INSTALL=--strip
+    #   env: CONFIG=Debug TOOLCHAIN=gcc-pic-hid-sections INSTALL=--strip
     - os: linux
       env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
     # - os: linux
@@ -76,7 +75,7 @@ install:
   # Install Python package 'requests'
   # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
   - if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
-  - if [[ "`uname`" == "Linux" ]]; then travis_retry easy_install3 --user requests==2.10.0; fi  
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi  
 
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip
@@ -94,7 +93,17 @@ install:
   - export ANDROID_NDK_r10e="`pwd`/_ci/android-ndk-r10e"
 
 script:
-    - polly.py --toolchain ${TOOLCHAIN} --config ${CONFIG} --verbose --fwd HUNTER_CONFIGURATION_TYPES=${CONFIG} --discard 10 --tail 100
+  
+  - >
+    polly.py
+    --toolchain ${TOOLCHAIN}
+    --config ${CONFIG}
+    --verbose
+    --fwd HUNTER_CONFIGURATION_TYPES=${CONFIG}
+    OGLES_GPGPU_BUILD_TESTS=ON
+    --test
+    --discard 10
+    --tail 100
 
 branches:
   except:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.18.29.tar.gz"
-  SHA1 "ebea5d2fa4aa70de1234b05c4bf1b69705abb1ba"
+  URL "https://github.com/ruslo/hunter/archive/v0.18.55.tar.gz"
+  SHA1 "0dcfb305e43e492bec485b7404827b3b5dd4d2e6"
   LOCAL
   )
 
@@ -35,40 +37,34 @@ option(OGLES_GPGPU_INSTALL "Perform installation" ON)
 option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
 
 ## #################################################################
-## Dependencies - OpenGL stuff
-## #################################################################
-
-if(MSVC)
-  hunter_add_package(glew)
-  find_package(glew CONFIG REQUIRED)
-endif()
-
-## #################################################################
 ## Testing: 
 ## #################################################################
 
-if(NOT (IOS OR ANDROID OR MSVC))
+# Tests can be compiled for all platforms (to tests exe linking),
+# but they may only be run on platforms where an OpenGL context
+# is available
   
-  option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)  
-  if(OGLES_GPGPU_BUILD_TESTS)
+option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
+if(OGLES_GPGPU_BUILD_TESTS)
 
-    enable_testing()    
+  enable_testing()    
 
-    hunter_add_package(GTest)
-    find_package(GTest CONFIG REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)
+  hunter_add_package(GTest)
+  find_package(GTest CONFIG REQUIRED)
+  list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)
 
-    # Include glfw for lightweight hidden window opengl context:
-    # Alternatives: boost or glm for iOS and Android
+  # Include glfw for lightweight hidden window opengl context:
+  # Alternatives: boost or glm for iOS and Android
+  if(NOT (IOS OR ANDROID))
     hunter_add_package(glfw)
     find_package(glfw3 REQUIRED)
     list(APPEND OGLES_GPGPU_TEST_LIBS glfw)
-    
-    hunter_add_package(OpenCV)
-    find_package(OpenCV REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS "${OpenCV_LIBS}")
-    
+    set(ogles_gpgpug_has_glfw TRUE)
   endif()
+  
+  hunter_add_package(OpenCV)
+  find_package(OpenCV REQUIRED)
+  list(APPEND OGLES_GPGPU_TEST_LIBS "${OpenCV_LIBS}")
 endif()
 
 ## #################################################################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
   - cmd: set MSYS_PATH=C:\msys64\usr\bin    
 
 build_script:
-  - cmd: python %POLLY_SOURCE_DIR%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --test
+  - cmd: python %POLLY_SOURCE_DIR%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --fwd OGLES_GPGPU_BUILD_TESTS=ON
   
 branches:
   except:

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,9 +1,48 @@
-set(OPENCV_CMAKE_ARGS
+=set(OPENCV_CMAKE_ARGS
 
+  BUILD_opencv_imgcodecs=ON  
+  BUILD_opencv_imgproc=ON
+  BUILD_opencv_video=ON
+  BUILD_opencv_videoio=ON
+  BUILD_opencv_highgui=ON  
+  
+  BUILD_opencv_calib3d=OFF
+  BUILD_opencv_contrib=OFF
+  BUILD_opencv_cudaarithm=OFF
+  BUILD_opencv_cudabgsegm=OFF
+  BUILD_opencv_cudacodec=OFF
+  BUILD_opencv_cudafeatures2d=OFF
+  BUILD_opencv_cudafilters=OFF
+  BUILD_opencv_cudaimgproc=OFF
+  BUILD_opencv_cudalegacy=OFF
+  BUILD_opencv_cudaobjdetect=OFF
+  BUILD_opencv_cudaoptflow=OFF
+  BUILD_opencv_cudastereo=OFF
+  BUILD_opencv_cudawarping=OFF
+  BUILD_opencv_cudev=OFF
+  BUILD_opencv_features2d=OFF
+  BUILD_opencv_flann=OFF
+  BUILD_opencv_gpu=OFF
+  BUILD_opencv_java=OFF
+  BUILD_opencv_legacy=OFF
+  BUILD_opencv_ml=OFF
+  BUILD_opencv_nonfree=OFF
+  BUILD_opencv_objdetect=OFF
+  BUILD_opencv_ocl=OFF
+  BUILD_opencv_photo=OFF
+  BUILD_opencv_python=OFF
+  BUILD_opencv_shape=OFF
+  BUILD_opencv_stitching=OFF
+  BUILD_opencv_superres=OFF
+  BUILD_opencv_ts=OFF
+  BUILD_opencv_videostab=OFF
+  BUILD_opencv_viz=OFF
+  BUILD_opencv_world=OFF
+  BUILD_opencv_apps=OFF  
+  
   BUILD_DOCS=OFF
   BUILD_TESTS=OFF
   BUILD_PERF_TESTS=OFF
-  BUILD_opencv_apps=OFF
   BUILD_EXAMPLES=OFF
   ENABLE_NEON=OFF
   BUILD_ANDROID_SERVICE=OFF
@@ -78,10 +117,4 @@ set(OPENCV_CMAKE_ARGS
   WITH_GPHOTO2=OFF        # "Include gPhoto2 library support"
   )
 
-if(APPLE)
-  set(ogles_gpgpu_opencv_version "3.0.0-p11")
-else()
-  set(ogles_gpgpu_opencv_version "${HUNTER_OpenCV_VERSION}")
-endif()
-
-hunter_config(OpenCV VERSION ${ogles_gpgpu_opencv_version} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+hunter_config(OpenCV VERSION 3.0.0-p11 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,4 @@
-=set(OPENCV_CMAKE_ARGS
+set(OPENCV_CMAKE_ARGS
 
   BUILD_opencv_imgcodecs=ON  
   BUILD_opencv_imgproc=ON

--- a/cmake/modules/CommonFindMod.cmake
+++ b/cmake/modules/CommonFindMod.cmake
@@ -1,0 +1,120 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+macro(drishti_common_find_module PREFIX PC_NAME HEADER LIBRARY)
+  unset(${PREFIX}_FOUND)
+  unset(${PREFIX}_DEFINITIONS)
+  unset(${PREFIX}_INCLUDE_DIRS)
+  unset(${PREFIX}_LIBRARY_DIRS)
+  unset(${PREFIX}_LIBRARIES)
+
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_${PREFIX} QUIET ${PC_NAME})
+    if(PC_${PREFIX}_FOUND)
+      find_library(
+        ${PREFIX}_FULL_LIB_PATH NAMES ${PC_${PREFIX}_LIBRARIES}
+        PATHS ${PC_${PREFIX}_LIBRARY_DIRS}
+        NO_DEFAULT_PATH
+        )
+      if("${${PREFIX}_FULL_LIB_PATH}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+        set(${PREFIX}_DEFINITIONS "${PC_${PREFIX}_STATIC_DEFINITIONS}")
+        set(${PREFIX}_INCLUDE_DIRS "${PC_${PREFIX}_STATIC_INCLUDE_DIRS}")
+        set(${PREFIX}_LIBRARY_DIRS "${PC_${PREFIX}_STATIC_LIBRARY_DIRS}")
+        set(${PREFIX}_LIBRARIES "${PC_${PREFIX}_STATIC_LIBRARIES}")
+        foreach(TMP_LIBRARY ${PC_${PREFIX}_STATIC_LIBRARIES})
+          find_library(
+            ${TMP_LIBRARY}_FULL_LIB_PATH NAMES ${TMP_LIBRARY}
+            HINTS ${PC_${PREFIX}_STATIC_LIBRARY_DIRS}
+            )
+          set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARIES} ${${TMP_LIBRARY}_FULL_LIB_PATH})
+          unset(TMP_FULL_LIB_PATH)
+        endforeach()
+      else()
+        set(${PREFIX}_DEFINITIONS "${PC_${PREFIX}_DEFINITIONS}")
+        set(${PREFIX}_INCLUDE_DIRS "${PC_${PREFIX}_INCLUDE_DIRS}")
+        set(${PREFIX}_LIBRARY_DIRS "${PC_${PREFIX}_LIBRARY_DIRS}")
+        foreach(TMP_LIBRARY ${PC_${PREFIX}_LIBRARIES})
+          find_library(
+            ${TMP_LIBRARY}_FULL_LIB_PATH NAMES ${TMP_LIBRARY}
+            HINTS ${LIBRARY_SEARCH_PATHS} ${PC_${PREFIX}_LIBRARY_DIRS}
+            )
+          set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARIES} ${${TMP_LIBRARY}_FULL_LIB_PATH})
+          unset(TMP_FULL_LIB_PATH)
+        endforeach()
+      endif()
+      unset(${PREFIX}_FULL_LIB_PATH)
+    endif()
+  endif()
+
+  if(NOT(${PREFIX}_INCLUDE_DIRS))
+    unset(${PREFIX}_INCLUDE_DIRS)
+    find_path(
+      ${PREFIX}_INCLUDE_DIRS ${HEADER}
+      PATHS ${HEADER_SEARCH_PATHS}
+      NO_DEFAULT_PATH
+      )
+  endif()
+  if(NOT(${PREFIX}_INCLUDE_DIRS))
+    unset(${PREFIX}_INCLUDE_DIRS)
+    find_path(${PREFIX}_INCLUDE_DIRS ${HEADER})
+  endif()
+
+  if(NOT ${PREFIX}_LIBRARIES)
+    find_library(
+      ${PREFIX}_LIBRARIES NAMES ${LIBRARY}
+      PATHS ${LIBRARY_SEARCH_PATHS}
+      NO_DEFAULT_PATH
+      )
+  endif()
+  if(NOT ${PREFIX}_LIBRARIES)
+    find_library(${PREFIX}_LIBRARIES NAMES ${LIBRARY})
+  endif()
+
+  set(${PREFIX}_FOUND 0)
+  if((${PREFIX}_INCLUDE_DIRS) AND (${PREFIX}_LIBRARIES))
+
+    if(EXISTS ${PROJECT_SOURCE_DIR}/config/ext_lib/test_${PREFIX}.cpp)
+      if(NOT ${PREFIX}_LIBRARIES)
+        set(${PREFIX}_LIBRARIES "")
+      endif()
+      configure_file(
+        ${PROJECT_SOURCE_DIR}/config/ext_lib/test_${PREFIX}.cpp
+        ${PROJECT_BINARY_DIR}/ext_lib/test_${PREFIX}.cpp
+        )
+      try_run(
+        RUNS_WITH_${PREFIX} COMPILES_WITH_${PREFIX}
+        "${PROJECT_BINARY_DIR}/ext_lib"
+        "${PROJECT_BINARY_DIR}/ext_lib/test_${PREFIX}.cpp"
+        COMPILE_DEFINITIONS
+        "${DRISHTI_CPP_STD_COMPILER_SWITCH} ${${PREFIX}_DEFINITIONS}"
+        CMAKE_FLAGS
+        "-DINCLUDE_DIRECTORIES:STRING=${${PREFIX}_INCLUDE_DIRS} "
+        "-DLIBRARY_DIRECTORIES:STRING=${${PREFIX}_LIBRARY_DIRS} "
+        "-DLINK_DIRECTORIES:STRING=${${PREFIX}_LIBRARY_DIRS} "
+        "-DLINK_LIBRARIES:STRING=${${PREFIX}_LIBRARIES} "
+        )
+      if(COMPILES_WITH_${PREFIX})
+        if(RUNS_WITH_${PREFIX} EQUAL 0)
+          set(${PREFIX}_FOUND 1)
+          message(STATUS
+            "Found ${PREFIX}: "
+            "${${PREFIX}_INCLUDE_DIRS} "
+            "${${PREFIX}_LIBRARIES}"
+            )
+        else()
+          message(STATUS "Could NOT execute with ${PREFIX}")
+        endif()
+      else()
+        message(STATUS "Could NOT compile or link with ${PREFIX}")
+      endif()
+      unset(RUNS_WITH_${PREFIX})
+      unset(COMPILES_WITH_${PREFIX})
+    else()
+      set(${PREFIX}_FOUND 1)
+      message(STATUS "Found ${PREFIX}: ${${PREFIX}_INCLUDE_DIRS} ${${PREFIX}_LIBRARIES}")
+    endif()
+  else()
+    message(STATUS "Could NOT find ${PREFIX}")
+  endif()
+endmacro()

--- a/cmake/modules/FindAndroid.cmake
+++ b/cmake/modules/FindAndroid.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+drishti_common_find_module(ANDROID android android/api-level.h android)

--- a/cmake/modules/FindEGL.cmake
+++ b/cmake/modules/FindEGL.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+drishti_common_find_module(EGL egl EGL/egl.h EGL)

--- a/cmake/modules/FindLog.cmake
+++ b/cmake/modules/FindLog.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+drishti_common_find_module(LOG log android/log.h log)

--- a/cmake/modules/FindOpenGLES2.cmake
+++ b/cmake/modules/FindOpenGLES2.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+drishti_common_find_module(OpenGLES2 GLESv2 GLES2/gl2.h GLESv2)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -1,28 +1,56 @@
 include(sugar_include)
 sugar_include(.)
 
-add_library(ogles_gpgpu ${OGLES_GPGPU_SRCS} )
+add_library(ogles_gpgpu ${OGLES_GPGPU_SRCS})
 
 if(OGLES_GPGPU_VERBOSE)
   target_compile_definitions(ogles_gpgpu PUBLIC OGLES_GPGPU_VERBOSE=1)
 endif()
 
-if(ANDROID)
+## #################################################################
+## Dependencies - OpenGL stuff
+## #################################################################
+
+if(APPLE)
+  if(IOS)
+    target_link_libraries(ogles_gpgpu PUBLIC
+      "-framework ImageIO"
+      "-framework CoreFoundation"
+      "-framework Foundation" # NSLog
+      "-framework OpenGLES"      
+      )    
+  else()
+    target_link_libraries(ogles_gpgpu PUBLIC
+      "-framework ImageIO"
+      "-framework CoreFoundation"
+      "-framework CoreVideo"
+      "-framework OpenGL"
+      )
+  endif()
+elseif(ANDROID)
+  find_package(Android REQUIRED)
+  find_package(Log REQUIRED)
+  find_package(EGL REQUIRED)
+  find_package(OpenGLES2 REQUIRED)
   target_link_libraries(ogles_gpgpu PUBLIC log android EGL GLESv2)
   target_compile_definitions(ogles_gpgpu PUBLIC EGL_EGLEXT_PROTOTYPES GL_GLEXT_PROTOTYPES)
+else()
+  find_package(OpenGL REQUIRED)
+  target_link_libraries(ogles_gpgpu PUBLIC OpenGL::GL)
+  if(MSVC)
+    # ogles_gpgpu/platform/opengl/gl_includes.h: #include <gl/glew.h>
+    hunter_add_package(glew)
+    find_package(glew CONFIG REQUIRED)
+    target_link_libraries(ogles_gpgpu PUBLIC glew::glew)
+    target_compile_definitions(ogles_gpgpu PUBLIC NOMINMAX) # avoid std::{min,max} conflicts
+    target_compile_definitions(ogles_gpgpu PUBLIC _USE_MATH_DEFINES) # M_PI, etc
+  endif()
 endif()
-
-if(MSVC)
-  target_link_libraries(ogles_gpgpu glew::glew)
-  target_compile_definitions(ogles_gpgpu PUBLIC NOMINMAX) # avoid std::{min,max} conflicts
-  target_compile_definitions(ogles_gpgpu PUBLIC _USE_MATH_DEFINES) # M_PI, etc
-endif()
-
+  
 set_property(TARGET ${library} PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
 )
-
 
 ## #################################################################
 ## Testing: 

--- a/ogles_gpgpu/common/proc/blend.cpp
+++ b/ogles_gpgpu/common/proc/blend.cpp
@@ -12,12 +12,11 @@
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *BlendProc::fshaderBlendSrc = OG_TO_STR
-(
+const char *BlendProc::fshaderBlendSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 textureCoordinate2;
 

--- a/ogles_gpgpu/common/proc/diff.cpp
+++ b/ogles_gpgpu/common/proc/diff.cpp
@@ -12,11 +12,11 @@
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *DiffProc::fshaderDiffSrc = OG_TO_STR
-(
+const char *DiffProc::fshaderDiffSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(    
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
@@ -27,7 +27,7 @@ const char *DiffProc::fshaderDiffSrc = OG_TO_STR
      vec4 centerIntensity = texture2D(inputImageTexture, textureCoordinate);
      vec4 centerIntensity2 = texture2D(inputImageTexture2, textureCoordinate);
      vec3 dt = (centerIntensity.rgb-centerIntensity2.rgb) * strength;
-     gl_FragColor = vec4(vec3(clamp(dt, 0.0, 1.0)), 1.0);
+     gl_FragColor = vec4(vec3(clamp(dt + offset, 0.0, 1.0)), 1.0);
  });
 // *INDENT-ON*
 

--- a/ogles_gpgpu/common/proc/disp.cpp
+++ b/ogles_gpgpu/common/proc/disp.cpp
@@ -14,12 +14,11 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *Disp::fshaderDispSrc = OG_TO_STR(
-
+const char *Disp::fshaderDispSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform sampler2D uInputTex;
 void main()

--- a/ogles_gpgpu/common/proc/fifo.cpp
+++ b/ogles_gpgpu/common/proc/fifo.cpp
@@ -35,11 +35,11 @@ private:
 };
 
 // *INDENT-OFF*
-const char * NoopProc::fshaderNoopSrc = OG_TO_STR
-(
+const char * NoopProc::fshaderNoopSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
+OG_TO_STR( 
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  uniform float gain;

--- a/ogles_gpgpu/common/proc/fir3.cpp
+++ b/ogles_gpgpu/common/proc/fir3.cpp
@@ -12,12 +12,11 @@
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *Fir3Proc::fshaderFir3Src = OG_TO_STR
-(
+const char *Fir3Proc::fshaderFir3Src =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;
@@ -37,12 +36,11 @@ const char *Fir3Proc::fshaderFir3Src = OG_TO_STR
      gl_FragColor = vec4(response * alpha + beta, 1.0);
  });
 
-const char *Fir3Proc::fshaderFir3RGBSrc = OG_TO_STR
-(
+const char *Fir3Proc::fshaderFir3RGBSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;

--- a/ogles_gpgpu/common/proc/flow.cpp
+++ b/ogles_gpgpu/common/proc/flow.cpp
@@ -100,12 +100,11 @@ void FlowProc::setUniforms() {
 // -------------
 
 // *INDENT-OFF*
-const char *FlowProc::fshaderFlowSrc = OG_TO_STR
-(
+const char *FlowProc::fshaderFlowSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
 
@@ -249,12 +248,11 @@ void FlowImplProc::setUniforms() {
 }
 
 // *INDENT-OFF*
-const char * FlowImplProc::fshaderFlowXSrc = OG_TO_STR
-(
+const char * FlowImplProc::fshaderFlowXSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform float strength;
@@ -270,12 +268,11 @@ const char * FlowImplProc::fshaderFlowXSrc = OG_TO_STR
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *FlowImplProc::fshaderFlowYSrc = OG_TO_STR
-(
+const char *FlowImplProc::fshaderFlowYSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform float strength;
@@ -317,12 +314,11 @@ void Flow2Proc::setUniforms() {
 }
 
 // *INDENT-OFF*
-const char *Flow2Proc::fshaderFlowSrc = OG_TO_STR
-(
+const char *Flow2Proc::fshaderFlowSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;

--- a/ogles_gpgpu/common/proc/gain.cpp
+++ b/ogles_gpgpu/common/proc/gain.cpp
@@ -10,11 +10,11 @@
 
 // *INDENT-OFF*
 BEGIN_OGLES_GPGPU
-const char * GainProc::fshaderGainSrc = OG_TO_STR
-(
+const char * GainProc::fshaderGainSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
+OG_TO_STR(
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  uniform float gain;
@@ -23,5 +23,14 @@ const char * GainProc::fshaderGainSrc = OG_TO_STR
      vec4 val = texture2D(uInputTex, vTexCoord);
      gl_FragColor = clamp(val * gain, 0.0, 1.0);
  });
+
+void GainProc::getUniforms() {
+    shParamUGain = shader->getParam(UNIF, "gain");
+}
+
+void GainProc::setUniforms() {
+    glUniform1f(shParamUGain, gain);
+}
+
 END_OGLES_GPGPU
 // *INDENT-ON*

--- a/ogles_gpgpu/common/proc/gain.h
+++ b/ogles_gpgpu/common/proc/gain.h
@@ -33,9 +33,7 @@ public:
     /**
      * Set the gain coefficient.
      */
-    void setGain(float value) {
-        gain = value;
-    }
+    void setGain(float value);
 
 private:
 
@@ -49,16 +47,12 @@ private:
     /**
      * Get shader uniform id.
      */
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
+    virtual void getUniforms();
 
     /**
      * Set shader uniform values.
      */
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
+    virtual void setUniforms();
 
     static const char *fshaderGainSrc; // fragment shader source
     float gain = 1.f;

--- a/ogles_gpgpu/common/proc/grad.cpp
+++ b/ogles_gpgpu/common/proc/grad.cpp
@@ -13,12 +13,11 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *GradProc::fshaderGradSrc = OG_TO_STR
-(
+const char *GradProc::fshaderGradSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;

--- a/ogles_gpgpu/common/proc/grayscale.cpp
+++ b/ogles_gpgpu/common/proc/grayscale.cpp
@@ -30,12 +30,13 @@ const GLfloat GrayscaleProc::grayscaleConvVecNone[3] = {
 };
 
 // *INDENT-OFF*
-const char *GrayscaleProc::fshaderGrayscaleSrc = OG_TO_STR(
+const char *GrayscaleProc::fshaderGrayscaleSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
 
+OG_TO_STR(
 uniform sampler2D uInputTex;
 uniform vec3 uInputConvVec;
 varying vec2 vTexCoord;
@@ -49,12 +50,13 @@ void main()
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *GrayscaleProc::fshaderNoopSrc = OG_TO_STR(
+const char *GrayscaleProc::fshaderNoopSrc =
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
 
+OG_TO_STR(
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  void main()

--- a/ogles_gpgpu/common/proc/harris.cpp
+++ b/ogles_gpgpu/common/proc/harris.cpp
@@ -15,13 +15,13 @@ using namespace ogles_gpgpu;
 // Try Harris:
 
 // *INDENT-OFF*
-const char *HarrisProc::fshaderHarrisSrc = OG_TO_STR(
+const char *HarrisProc::fshaderHarrisSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-varying OGLES_GPGPU_HIGHP vec2 textureCoordinate;
+OG_TO_STR(
+varying vec2 textureCoordinate;
 
 uniform sampler2D inputImageTexture;
 uniform float sensitivity;

--- a/ogles_gpgpu/common/proc/hessian.cpp
+++ b/ogles_gpgpu/common/proc/hessian.cpp
@@ -41,12 +41,12 @@ using namespace ogles_gpgpu;
 // Source: GPUImageXYDerivativeFilter.m
 
 // *INDENT-OFF*
-const char *HessianProc::fshaderHessianAndDeterminantSrc = OG_TO_STR(
+const char *HessianProc::fshaderHessianAndDeterminantSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;
@@ -105,12 +105,12 @@ void main()
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *HessianProc::fshaderDeterminantSrc = OG_TO_STR(
+const char *HessianProc::fshaderDeterminantSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+ OG_TO_STR(precision highp float;)
 #endif
-
+ OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;

--- a/ogles_gpgpu/common/proc/hsv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/hsv2rgb.cpp
@@ -12,12 +12,11 @@
 
 BEGIN_OGLES_GPGPU
 // *INDENT-OFF*
-const char * Hsv2RgbProc::fshaderHsv2RgbSrc = OG_TO_STR
-(
+const char * Hsv2RgbProc::fshaderHsv2RgbSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
   vec3 hsv2rgb(vec3 c)
   {
     vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
@@ -27,7 +26,6 @@ const char * Hsv2RgbProc::fshaderHsv2RgbSrc = OG_TO_STR
 
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
- uniform float gain;
  void main()
  {
      vec4 val = texture2D(uInputTex, vTexCoord);

--- a/ogles_gpgpu/common/proc/hsv2rgb.h
+++ b/ogles_gpgpu/common/proc/hsv2rgb.h
@@ -11,13 +11,14 @@
 #ifndef OGLES_GPGPU_COMMON_HSV2RGB_PROC
 #define OGLES_GPGPU_COMMON_HSV2RGB_PROC
 
+#include "../common_includes.h"
 #include "ogles_gpgpu/common/proc/base/filterprocbase.h"
 
 BEGIN_OGLES_GPGPU
 
 class Hsv2RgbProc : public ogles_gpgpu::FilterProcBase {
 public:
-    Hsv2RgbProc(float gain=1.f) : gain(gain) {}
+    Hsv2RgbProc() {}
     virtual const char *getProcName() {
         return "Hsv2RgbProc";
     }
@@ -25,15 +26,8 @@ private:
     virtual const char *getFragmentShaderSource() {
         return fshaderHsv2RgbSrc;
     }
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
+
     static const char *fshaderHsv2RgbSrc; // fragment shader source
-    float gain = 1.f;
-    GLint shParamUGain;
 };
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/ixyt.cpp
+++ b/ogles_gpgpu/common/proc/ixyt.cpp
@@ -26,12 +26,11 @@ void IxytProc::setUniforms() {
 }
 
 // *INDENT-OFF*
-const char *IxytProc::fshaderIxytSrc = OG_TO_STR
-(
+const char *IxytProc::fshaderIxytSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;

--- a/ogles_gpgpu/common/proc/lbp.cpp
+++ b/ogles_gpgpu/common/proc/lbp.cpp
@@ -13,12 +13,12 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *LbpProc::fshaderLbpSrc = OG_TO_STR(
+const char *LbpProc::fshaderLbpSrc =
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;
@@ -35,17 +35,17 @@ uniform sampler2D inputImageTexture;
 
 void main()
 {
-   OGLES_GPGPU_LOWP float centerIntensity = texture2D(inputImageTexture, textureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomLeftIntensity = texture2D(inputImageTexture, bottomLeftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topRightIntensity = texture2D(inputImageTexture, topRightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topLeftIntensity = texture2D(inputImageTexture, topLeftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomRightIntensity = texture2D(inputImageTexture, bottomRightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float leftIntensity = texture2D(inputImageTexture, leftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float rightIntensity = texture2D(inputImageTexture, rightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomIntensity = texture2D(inputImageTexture, bottomTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topIntensity = texture2D(inputImageTexture, topTextureCoordinate).r;
+    float centerIntensity = texture2D(inputImageTexture, textureCoordinate).r;
+    float bottomLeftIntensity = texture2D(inputImageTexture, bottomLeftTextureCoordinate).r;
+    float topRightIntensity = texture2D(inputImageTexture, topRightTextureCoordinate).r;
+    float topLeftIntensity = texture2D(inputImageTexture, topLeftTextureCoordinate).r;
+    float bottomRightIntensity = texture2D(inputImageTexture, bottomRightTextureCoordinate).r;
+    float leftIntensity = texture2D(inputImageTexture, leftTextureCoordinate).r;
+    float rightIntensity = texture2D(inputImageTexture, rightTextureCoordinate).r;
+    float bottomIntensity = texture2D(inputImageTexture, bottomTextureCoordinate).r;
+    float topIntensity = texture2D(inputImageTexture, topTextureCoordinate).r;
 
-   OGLES_GPGPU_LOWP float byteTally = 1.0 / 255.0 * step(centerIntensity, topRightIntensity);
+    float byteTally = 1.0 / 255.0 * step(centerIntensity, topRightIntensity);
    byteTally += 2.0 / 255.0 * step(centerIntensity, topIntensity);
    byteTally += 4.0 / 255.0 * step(centerIntensity, topLeftIntensity);
    byteTally += 8.0 / 255.0 * step(centerIntensity, leftIntensity);

--- a/ogles_gpgpu/common/proc/median.cpp
+++ b/ogles_gpgpu/common/proc/median.cpp
@@ -53,11 +53,11 @@ BEGIN_OGLES_GPGPU
 MedianProc::MedianProc() : Filter3x3Proc() {}
 
 // *INDENT-OFF*
-const char *MedianProc::fshaderMedianSrc = OG_TO_STR
-(
+const char *MedianProc::fshaderMedianSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(
 
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
@@ -76,7 +76,6 @@ const char *MedianProc::fshaderMedianSrc = OG_TO_STR
 #define s2(a, b)				temp = a; a = min(a, b); b = max(temp, b);
 #define mn3(a, b, c)			s2(a, b); s2(a, c);
 #define mx3(a, b, c)			s2(b, c); s2(a, c);
-
 #define mnmx3(a, b, c)			mx3(a, b, c); s2(a, b);                                   // 3 exchanges
 #define mnmx4(a, b, c, d)		s2(a, b); s2(c, d); s2(a, c); s2(b, d);                   // 4 exchanges
 #define mnmx5(a, b, c, d, e)	s2(a, b); s2(c, d); mn3(a, c, e); mx3(b, d, e);           // 6 exchanges
@@ -85,15 +84,12 @@ const char *MedianProc::fshaderMedianSrc = OG_TO_STR
  void main()
  {
      vec3 v[6];
-
      v[0] = texture2D(inputImageTexture, bottomLeftTextureCoordinate).rgb;
      v[1] = texture2D(inputImageTexture, topRightTextureCoordinate).rgb;
      v[2] = texture2D(inputImageTexture, topLeftTextureCoordinate).rgb;
      v[3] = texture2D(inputImageTexture, bottomRightTextureCoordinate).rgb;
      v[4] = texture2D(inputImageTexture, leftTextureCoordinate).rgb;
      v[5] = texture2D(inputImageTexture, rightTextureCoordinate).rgb;
-//     v[6] = texture2D(inputImageTexture, bottomTextureCoordinate).rgb;
-//     v[7] = texture2D(inputImageTexture, topTextureCoordinate).rgb;
      vec3 temp;
 
      mnmx6(v[0], v[1], v[2], v[3], v[4], v[5]);

--- a/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.cpp
@@ -18,12 +18,12 @@ using namespace ogles_gpgpu;
 // Requires a grayscale image as input!
 
 // *INDENT-OFF*
-const char *AdaptThreshProcPass::fshaderAdaptThreshPass1Src = OG_TO_STR(
+const char *AdaptThreshProcPass::fshaderAdaptThreshPass1Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform vec2 uPxD;
 uniform sampler2D uInputTex;
@@ -49,12 +49,12 @@ void main() {
 // the final binarization
 
 // *INDENT-OFF*
-const char *AdaptThreshProcPass::fshaderAdaptThreshPass2Src = OG_TO_STR(
+const char *AdaptThreshProcPass::fshaderAdaptThreshPass2Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform vec2 uPxD;
 uniform sampler2D uInputTex;

--- a/ogles_gpgpu/common/proc/multipass/gauss_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/gauss_pass.cpp
@@ -17,8 +17,7 @@ using namespace ogles_gpgpu;
 // #### 7 tap filters ####
 
 // *INDENT-OFF*
-const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR
-(
+const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -52,12 +51,11 @@ const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss7Src = OG_TO_STR
-(
+const char *GaussProcPass::fshaderGauss7Src = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN3;
@@ -92,12 +90,11 @@ void main()
 // 1/64 = 0.015625
 
 // *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss7SrcR = OG_TO_STR
-(
+const char *GaussProcPass::fshaderGauss7SrcR =
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN3;
@@ -127,8 +124,7 @@ void main()
 // #### 5 tap filters ####
 
 // *INDENT-OFF*
-const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR
-(
+const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -158,13 +154,12 @@ const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss5Src = OG_TO_STR
-(
+const char *GaussProcPass::fshaderGauss5Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+ OG_TO_STR(precision highp float;)
 #endif
-
+ OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN2;
@@ -194,12 +189,11 @@ const char *GaussProcPass::fshaderGauss5Src = OG_TO_STR
 // 1/16 = 0.0625
 
 // *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss5SrcR = OG_TO_STR
-(
+const char *GaussProcPass::fshaderGauss5SrcR = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN2;

--- a/ogles_gpgpu/common/proc/multipass/local_norm_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/local_norm_pass.cpp
@@ -11,15 +11,15 @@
 
 using namespace ogles_gpgpu;
 
-const char *LocalNormPass::fshaderLocalNormPass1Src = OG_TO_STR
-        (
+// *INDENT-OFF*
+const char *LocalNormPass::fshaderLocalNormPass1Src = 
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-            uniform sampler2D uInputTex;
-            uniform float uPxD;
-            varying vec2 vTexCoord;
+OG_TO_STR(
+uniform sampler2D uInputTex;
+uniform float uPxD;
+varying vec2 vTexCoord;
 // 7x1 Gauss kernel
 void main() {
     vec4 pxC  = texture2D(uInputTex, vTexCoord);
@@ -33,17 +33,18 @@ void main() {
 
     gl_FragColor = vec4(pxC.rgb, val); // {r,g,b,r_mean}
 });
+// *INDENT-ON*
 
-const char *LocalNormPass::fshaderLocalNormPass2Src = OG_TO_STR
-        (
+// *INDENT-OFF*
+const char *LocalNormPass::fshaderLocalNormPass2Src =
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-            uniform sampler2D uInputTex;
-            uniform float uPxD;
-            uniform float normConst;
-            varying vec2 vTexCoord;
+OG_TO_STR(
+uniform sampler2D uInputTex;
+uniform float uPxD;
+uniform float normConst;
+varying vec2 vTexCoord;
 // 7x1 Gauss kernel
 void main() {
     vec4 pxC  = texture2D(uInputTex, vTexCoord);
@@ -59,6 +60,7 @@ void main() {
 
     gl_FragColor = vec4(clamp(0.5 * rNorm, 0.0, 1.0), pxC.g, pxC.r, val); // {r_norm,g,r,r_mean}
 });
+// *INDENT-ON*
 
 int LocalNormPass::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
     OG_LOGINF(getProcName(), "render pass %d", renderPass);

--- a/ogles_gpgpu/common/proc/nms.cpp
+++ b/ogles_gpgpu/common/proc/nms.cpp
@@ -15,12 +15,11 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *NmsProc::fshaderNmsSrc = OG_TO_STR
-(
+const char *NmsProc::fshaderNmsSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision OGLES_GPGPU_HIGHP float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinate;

--- a/ogles_gpgpu/common/proc/remap.cpp
+++ b/ogles_gpgpu/common/proc/remap.cpp
@@ -27,11 +27,11 @@ const char *RemapProc::vshaderRemapSrc = OG_TO_STR
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *RemapProc::fshaderRemapSrc = OG_TO_STR
-(
+const char *RemapProc::fshaderRemapSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(    
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;  // IMAGE
  uniform sampler2D inputImageTexture2; // FLOW

--- a/ogles_gpgpu/common/proc/rgb2hsv.cpp
+++ b/ogles_gpgpu/common/proc/rgb2hsv.cpp
@@ -12,12 +12,11 @@
 
 // *INDENT-OFF*
 BEGIN_OGLES_GPGPU
-const char * Rgb2HsvProc::fshaderRgb2HsvSrc = OG_TO_STR
-(
+const char * Rgb2HsvProc::fshaderRgb2HsvSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  vec3 rgb2hsv(vec3 c)
  {
     vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
@@ -31,11 +30,11 @@ const char * Rgb2HsvProc::fshaderRgb2HsvSrc = OG_TO_STR
 
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
- uniform float gain;
  void main()
  {
      vec4 val = texture2D(uInputTex, vTexCoord);
      gl_FragColor = vec4(rgb2hsv(val.rgb), 1.0);
  });
+
 END_OGLES_GPGPU
 // *INDENT-ON*

--- a/ogles_gpgpu/common/proc/rgb2hsv.h
+++ b/ogles_gpgpu/common/proc/rgb2hsv.h
@@ -9,13 +9,14 @@
 #ifndef OGLES_GPGPU_COMMON_RGB2HSV_PROC
 #define OGLES_GPGPU_COMMON_RGB2HSV_PROC
 
+#include "../common_includes.h"
 #include "ogles_gpgpu/common/proc/base/filterprocbase.h"
 
 BEGIN_OGLES_GPGPU
 
 class Rgb2HsvProc : public ogles_gpgpu::FilterProcBase {
 public:
-    Rgb2HsvProc(float gain=1.f) : gain(gain) {}
+    Rgb2HsvProc() {}
     virtual const char *getProcName() {
         return "Rgb2HsvProc";
     }
@@ -23,17 +24,8 @@ private:
     virtual const char *getFragmentShaderSource() {
         return fshaderRgb2HsvSrc;
     }
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
+
     static const char *fshaderRgb2HsvSrc; // fragment shader source
-    float gain = 1.f;
-    GLint shParamUGain;
 };
-
 END_OGLES_GPGPU
-
 #endif

--- a/ogles_gpgpu/common/proc/shitomasi.cpp
+++ b/ogles_gpgpu/common/proc/shitomasi.cpp
@@ -12,15 +12,13 @@
 using namespace std;
 using namespace ogles_gpgpu;
 
-
-
 // *INDENT-OFF*
-const char *ShiTomasiProc::fshaderShiTomasiSrc = OG_TO_STR(
+const char *ShiTomasiProc::fshaderShiTomasiSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 
 uniform sampler2D inputImageTexture;

--- a/ogles_gpgpu/common/proc/tensor.cpp
+++ b/ogles_gpgpu/common/proc/tensor.cpp
@@ -15,12 +15,12 @@ using namespace ogles_gpgpu;
 // Source: GPUImageXYDerivativeFilter.m
 
 // *INDENT-OFF*
-const char *TensorProc::fshaderTensorSrc = OG_TO_STR(
+const char *TensorProc::fshaderTensorSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;

--- a/ogles_gpgpu/common/proc/three.cpp
+++ b/ogles_gpgpu/common/proc/three.cpp
@@ -12,12 +12,12 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *ThreeInputProc::vshaderThreeInputSrc = OG_TO_STR(
+const char *ThreeInputProc::vshaderThreeInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -29,12 +29,12 @@ precision mediump float;
      textureCoordinate = inputTextureCoordinate.xy;
  });
 
-const char *ThreeInputProc::fshaderThreeInputSrc = OG_TO_STR(
+const char *ThreeInputProc::fshaderThreeInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;

--- a/ogles_gpgpu/common/proc/thresh.cpp
+++ b/ogles_gpgpu/common/proc/thresh.cpp
@@ -17,21 +17,23 @@ using namespace ogles_gpgpu;
 
 // Simple thresholding fragment shader
 // Requires a grayscale image as input!
-const char *ThreshProc::fshaderSimpleThreshSrc = OG_TO_STR(
+
+// *INDENT-OFF*
+const char *ThreshProc::fshaderSimpleThreshSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
-            varying vec2 vTexCoord;
-            uniform float uThresh;
-            uniform sampler2D uInputTex;
+OG_TO_STR(
+varying vec2 vTexCoord;
+uniform float uThresh;
+uniform sampler2D uInputTex;
 void main() {
     float gray = texture2D(uInputTex, vTexCoord).r;
     float bin = step(uThresh, gray);
     gl_FragColor = vec4(bin, bin, bin, 1.0);
-}
-        );
+});
+// *INDENT-ON*
 
 ThreshProc::ThreshProc() {
     // set defaults

--- a/ogles_gpgpu/common/proc/transform.cpp
+++ b/ogles_gpgpu/common/proc/transform.cpp
@@ -30,12 +30,12 @@ void main()
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *TransformProc::fshaderTransformSrc = OG_TO_STR(
+const char *TransformProc::fshaderTransformSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform sampler2D uInputTex;
 void main()
@@ -46,13 +46,13 @@ void main()
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *TransformProc::fshaderTransformBicubicSrc = OG_TO_STR(
+const char *TransformProc::fshaderTransformBicubicSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-vec4 cubic(OGLES_GPGPU_HIGHP float v)
+OG_TO_STR(
+vec4 cubic(float v)
 {
     vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
     vec4 s = n * n * n;
@@ -64,7 +64,7 @@ vec4 cubic(OGLES_GPGPU_HIGHP float v)
     return result;
 }
 
-vec4 textureBicubic(sampler2D sampler, OGLES_GPGPU_HIGHP vec2 texCoords, OGLES_GPGPU_HIGHP vec2 texSize)
+vec4 textureBicubic(sampler2D sampler, vec2 texCoords, vec2 texSize)
 {
     vec2 invTexSize = 1.0 / texSize;
 

--- a/ogles_gpgpu/common/proc/two.cpp
+++ b/ogles_gpgpu/common/proc/two.cpp
@@ -13,12 +13,12 @@ using namespace std;
 using namespace ogles_gpgpu;
 
 // *INDENT-OFF*
-const char *TwoInputProc::vshaderTwoInputSrc = OG_TO_STR(
+const char *TwoInputProc::vshaderTwoInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -32,12 +32,12 @@ precision mediump float;
 // *INDENT-ON*
 
 // *INDENT-OFF*
-const char *TwoInputProc::fshaderTwoInputSrc = OG_TO_STR(
+const char *TwoInputProc::fshaderTwoInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;

--- a/ogles_gpgpu/common/proc/yuv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/yuv2rgb.cpp
@@ -53,76 +53,80 @@ void setColorConversion709( GLfloat conversionMatrix[9] ) {
 }
 
 // *INDENT-OFF*
-const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = OG_TO_STR(
+const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = 
 
-#if defined(OGLES_GPGPU_OPENGLES)
-  precision mediump float;
-#endif
-
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+//#if defined(OGLES_GPGPU_OPENGLES)
+//OG_TO_STR(precision mediump float;)
+//#endif
+OG_TO_STR(
+          
+ precision mediump float;
+          
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r;
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).rg - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
+ });
 // *INDENT-ON*
 
 // *INDENT-OFF*
 const char *kGPUImageYUVFullRangeConversionForLAFragmentShaderString = OG_TO_STR(
-
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+                        
+ precision mediump float;
+                                                                                 
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r;
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).ra - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
+ });
 // *INDENT-ON*
 
 // *INDENT-OFF*
 const char *kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = OG_TO_STR(
 
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+ precision mediump float;
+                                                                                  
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r - (16.0/255.0);
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).ra - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
+ });
 // *INDENT-ON*
 
 // =================================================================================

--- a/ogles_gpgpu/ut/CMakeLists.txt
+++ b/ogles_gpgpu/ut/CMakeLists.txt
@@ -5,7 +5,14 @@ add_executable(${test_app} test-ogles_gpgpu.cpp)
 target_link_libraries(${test_app} PUBLIC ogles_gpgpu ${OGLES_GPGPU_TEST_LIBS})
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/tests")
 
-add_test(
-  NAME "${test_name}"
-  COMMAND "${test_app}"
-  )
+if(ogles_gpgpug_has_glfw)
+  target_compile_definitions(${test_app} PUBLIC OGLES_GPGPU_HAS_GLFW=1)
+endif()
+
+if(NOT (IOS OR ANDROID))
+  # TODO: Lightweight portable OpenGL context for mobile platforms  
+  add_test(
+    NAME "${test_name}"
+    COMMAND "${test_app}"
+    )
+endif()


### PR DESCRIPTION
* shader string fixes to support visual studio
    + avoid #define inside shader strings for vs-14-2015
    + use consistent top level precision declarations (drop per delcaration precision)
    + add some missing astyle `// *INDENT-{ON,OFF}* ` guards
    + avoid median filter test for `defined(_WIN32) || defined(_WIN64)` due to reliance on internal #define
* use glfw for all but ios
* remove unused; move gl calls to cpp
* traivs.yml
  + update to trusty + gcc-pic-hid-sections
  + remove “—strip” for os=linux to avoid issue with autoconf project
  + fix linux==travis pip3
* restrict opencv build (unit tests) to core + imgproc + highgui (minimal)
* udpate hunter
* add glew.h before glfw.h for ogles_gpgpu test
* fix msvc + typos
* fix target_compile_definitions
* Update fork to latest from hunter-packagers for CI testing